### PR TITLE
feat: Add naming conventions for private functions, variabes... in Python

### DIFF
--- a/.cursor/rules/02-programming-languages/2-python-naming-conventions.mdc
+++ b/.cursor/rules/02-programming-languages/2-python-naming-conventions.mdc
@@ -13,7 +13,9 @@ Functions and Methods:
 - Use verbs for actions
 - Use nouns for value-returning functions
 - Prefix booleans with is_, has_, should_
+- Prefix private functions and methods with _
 
 Variables and Constants:
 - Use snake_case for variable names
 - Use UPPER_SNAKE_CASE for constants
+- Prefix private variables and constants with _


### PR DESCRIPTION
Add naming conventions for private functions, methods, variabes and constants in Python

## ✅ Type of PR

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 🗒️ Description

Add Python naming conventions for private elements

Add rules to prefix private elements with underscore `_` in:
- Functions and methods
- Variables and constants

See: https://peps.python.org/pep-0008/#descriptive-naming-styles
